### PR TITLE
Allow :focus-visible to appear escaped in a selector

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,6 +1,6 @@
 import postcss from 'postcss';
 
-const selectorRegExp = /:focus-visible([^\w-]|$)/gi;
+const selectorRegExp = /(?<!\\):focus-visible([^\w-]|$)/gi;
 
 export default postcss.plugin('postcss-focus-visible', opts => {
 	const replaceWith = String(Object(opts).replaceWith || '.focus-visible');

--- a/test/basic.css
+++ b/test/basic.css
@@ -25,3 +25,10 @@ test :matches(test :focus-visible :focus-visible test) test {
 :focus-visibleignore {
 	order: 3;
 }
+
+.escaped\:focus-visible,
+.escaped\:times\:two\:focus-visible,
+.escaped\:focus-visible:focus-visible,
+.escaped\:times\:two:focus-visible {
+	order: 4;
+}

--- a/test/basic.expect.css
+++ b/test/basic.expect.css
@@ -46,3 +46,17 @@ test :matches(test :focus-visible :focus-visible test) test {
 :focus-visibleignore {
 	order: 3;
 }
+
+.escaped\:focus-visible,
+.escaped\:times\:two\:focus-visible,
+.escaped\:focus-visible.focus-visible,
+.escaped\:times\:two.focus-visible {
+	order: 4;
+}
+
+.escaped\:focus-visible,
+.escaped\:times\:two\:focus-visible,
+.escaped\:focus-visible:focus-visible,
+.escaped\:times\:two:focus-visible {
+	order: 4;
+}

--- a/test/basic.preserve.expect.css
+++ b/test/basic.preserve.expect.css
@@ -25,3 +25,10 @@ test :matches(test .focus-visible .focus-visible test) test {
 :focus-visibleignore {
 	order: 3;
 }
+
+.escaped\:focus-visible,
+.escaped\:times\:two\:focus-visible,
+.escaped\:focus-visible.focus-visible,
+.escaped\:times\:two.focus-visible {
+	order: 4;
+}

--- a/test/basic.replacewith.expect.css
+++ b/test/basic.replacewith.expect.css
@@ -46,3 +46,17 @@ test :matches(test :focus-visible :focus-visible test) test {
 :focus-visibleignore {
 	order: 3;
 }
+
+.escaped\:focus-visible,
+.escaped\:times\:two\:focus-visible,
+.escaped\:focus-visible[focus-visible],
+.escaped\:times\:two[focus-visible] {
+	order: 4;
+}
+
+.escaped\:focus-visible,
+.escaped\:times\:two\:focus-visible,
+.escaped\:focus-visible:focus-visible,
+.escaped\:times\:two:focus-visible {
+	order: 4;
+}

--- a/test/basic.replacewith.result.css
+++ b/test/basic.replacewith.result.css
@@ -46,3 +46,17 @@ test :matches(test :focus-visible :focus-visible test) test {
 :focus-visibleignore {
 	order: 3;
 }
+
+.escaped\:focus-visible,
+.escaped\:times\:two\:focus-visible,
+.escaped\:focus-visible[focus-visible],
+.escaped\:times\:two[focus-visible] {
+	order: 4;
+}
+
+.escaped\:focus-visible,
+.escaped\:times\:two\:focus-visible,
+.escaped\:focus-visible:focus-visible,
+.escaped\:times\:two:focus-visible {
+	order: 4;
+}

--- a/test/basic.result.css
+++ b/test/basic.result.css
@@ -46,3 +46,17 @@ test :matches(test :focus-visible :focus-visible test) test {
 :focus-visibleignore {
 	order: 3;
 }
+
+.escaped\:focus-visible,
+.escaped\:times\:two\:focus-visible,
+.escaped\:focus-visible.focus-visible,
+.escaped\:times\:two.focus-visible {
+	order: 4;
+}
+
+.escaped\:focus-visible,
+.escaped\:times\:two\:focus-visible,
+.escaped\:focus-visible:focus-visible,
+.escaped\:times\:two:focus-visible {
+	order: 4;
+}


### PR DESCRIPTION
cc @adamwathan @brandonpittman

This has the same travis problem as my focus-within PR. The earliest passing node version seems to be Node 8.10.